### PR TITLE
config-service backend support for fetch all keys

### DIFF
--- a/src/github.com/kelseyhightower/confd/backends/config-service/client.go
+++ b/src/github.com/kelseyhightower/confd/backends/config-service/client.go
@@ -57,10 +57,7 @@ func (c *Client) GetValues(keys []string) (map[string]string, error) {
 	for _, v := range keys {
 		bucketsKey := strings.Split(strings.TrimPrefix(v, "/"), "/")
 		buckets := strings.Split(bucketsKey[0], ",")
-		var key string
-		if len(bucketsKey) >= 2 {
-			key = bucketsKey[1]
-		}
+		key := bucketsKey[1]
 
 		dynamicBuckets, err := c.getDynamicBuckets(buckets)
 		if err != nil {


### PR DESCRIPTION
Added support to fetch all keys from bucket when "keys" in toml is empty or '/'
example toml file:
`keys: [  "/" ]
`